### PR TITLE
Add safe area padding to nav and sidebars

### DIFF
--- a/src/app/(root)/layout.tsx
+++ b/src/app/(root)/layout.tsx
@@ -9,7 +9,7 @@ export default function RootLayout({
   return (
     <div className="w-full min-h-screen flex flex-col">
       <TopNav />
-      <main className="flex-1">{children}</main>
+      <main className="flex-1 pt-[env(safe-area-inset-top)]">{children}</main>
       <Footer />
     </div>
   );

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -20,12 +20,12 @@ export default function DashboardLayout({
   return (
     <AuthProviderWrapper>
       <SidebarProvider defaultOpen={false}>
-        <div className="flex w-full min-h-screen flex-col">
+        <div className="flex w-full min-h-screen flex-col pt-[env(safe-area-inset-top)]">
           <MobileTopNav />
           <div className="flex flex-1">
             <DashboardSidebar />
             <main className="flex-1 flex justify-center">
-              <div className="container flex flex-col space-y-4 py-8 max-sm:pt-4">
+              <div className="container flex flex-col space-y-4 py-8 max-sm:pt-4 max-sm:pl-[env(safe-area-inset-left)] max-sm:pr-[env(safe-area-inset-right)]">
                 <Breadcrumbs />
                 {children}
               </div>

--- a/src/components/MobileAwareSidebar.tsx
+++ b/src/components/MobileAwareSidebar.tsx
@@ -36,6 +36,7 @@ export function MobileAwareSidebar({
           className={cn(
             "fixed inset-y-0 z-50 h-svh w-[--sidebar-width] transition-all duration-300 ease-out",
             "left-0 border-r border-sidebar-border",
+            "pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]",
             openMobile ? "translate-x-0" : "-translate-x-full",
             className
           )}
@@ -47,7 +48,7 @@ export function MobileAwareSidebar({
         >
           <div
             data-sidebar="sidebar"
-            className="flex h-full w-full flex-col bg-sidebar p-4"
+            className="flex h-full w-full flex-col bg-sidebar p-4 pl-[max(1rem,env(safe-area-inset-left))] pr-[max(1rem,env(safe-area-inset-right))]"
           >
             {children}
           </div>

--- a/src/components/MobileTopNav.tsx
+++ b/src/components/MobileTopNav.tsx
@@ -36,7 +36,7 @@ export function MobileTopNav() {
 
   return (
     <div
-      className={`sticky top-0 z-20 flex h-14 items-center gap-2 px-4 md:hidden transition-all duration-300 ${
+      className={`sticky top-0 z-20 flex h-14 items-center gap-2 px-4 md:hidden transition-all duration-300 pl-[max(1rem,env(safe-area-inset-left))] pr-[max(1rem,env(safe-area-inset-right))] pt-[env(safe-area-inset-top)] ${
         isScrolled
           ? "backdrop-blur-md bg-white/80 dark:bg-gray-900/80 shadow-sm"
           : "bg-background"

--- a/src/components/root/Footer.tsx
+++ b/src/components/root/Footer.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 export function Footer() {
   return (
     <footer className="border-t bg-background">
-      <div className="container mx-auto px-4 py-6">
+      <div className="container mx-auto px-4 py-6 pb-[max(1.5rem,env(safe-area-inset-bottom))] pl-[max(1rem,env(safe-area-inset-left))] pr-[max(1rem,env(safe-area-inset-right))]">
         <div className="flex flex-col md:flex-row justify-between items-center gap-4">
           <div className="text-sm text-muted-foreground">
             © {new Date().getFullYear()} Scheddly. All rights reserved.

--- a/src/components/root/TopNav.tsx
+++ b/src/components/root/TopNav.tsx
@@ -55,7 +55,7 @@ export function TopNav() {
           : "bg-transparent"
       }`}
     >
-      <div className="flex h-16 items-center justify-between w-full px-8">
+      <div className="flex h-16 items-center justify-between w-full px-8 pl-[max(2rem,env(safe-area-inset-left))] pr-[max(2rem,env(safe-area-inset-right))] pt-[env(safe-area-inset-top)]">
         <div className="flex items-center gap-8">
           <Link href="/" className="text-xl font-bold flex gap-2 items-center">
             <Image src="/logo.svg" alt="Logo" width={20} height={20} />


### PR DESCRIPTION
Add safe area padding to top navigation, sidebars, and footers to ensure UI elements respect device safe areas on mobile.

---
<a href="https://cursor.com/background-agent?bcId=bc-477e7f80-a062-46f5-a0c2-ea4111240ba1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-477e7f80-a062-46f5-a0c2-ea4111240ba1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>