### PR TITLE
Fix sidebar theme colors for dark mode

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10,6 +10,10 @@
     --card-foreground: 260 20% 20%;
     --sidebar: 0 0% 98%;
     --sidebar-foreground: 260 20% 20%;
+    --sidebar-border: 260 10% 90%;
+    --sidebar-accent: 260 20% 96%;
+    --sidebar-accent-foreground: 260 20% 20%;
+    --sidebar-ring: 270 45% 45%;
     --popover: 0 0% 100%;
     --popover-foreground: 260 20% 20%;
     --primary: 270 45% 45%;
@@ -48,6 +52,12 @@
     --foreground: 260 10% 98%;
     --card: 260 20% 15%;
     --card-foreground: 260 10% 98%;
+    --sidebar: 260 20% 15%;
+    --sidebar-foreground: 260 10% 98%;
+    --sidebar-border: 260 20% 25%;
+    --sidebar-accent: 260 20% 25%;
+    --sidebar-accent-foreground: 260 10% 98%;
+    --sidebar-ring: 270 45% 65%;
     --popover: 260 20% 15%;
     --popover-foreground: 260 10% 98%;
     --primary: 270 45% 65%;

--- a/src/components/MobileAwareSidebar.tsx
+++ b/src/components/MobileAwareSidebar.tsx
@@ -26,7 +26,7 @@ export function MobileAwareSidebar({
         {/* Overlay */}
         <div
           className={cn(
-            "fixed inset-0 z-40 bg-black/50 transition-opacity duration-300 ease-out md:hidden",
+            "fixed inset-0 z-40 bg-background/50 transition-opacity duration-300 ease-out md:hidden",
             openMobile ? "opacity-100" : "opacity-0 pointer-events-none"
           )}
           onClick={() => setOpenMobile(false)}

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -528,13 +528,13 @@ const SidebarMenuItem = React.forwardRef<
 SidebarMenuItem.displayName = "SidebarMenuItem";
 
 const sidebarMenuButtonVariants = cva(
-  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-none ring-sidebar-ring transition-[width,height,padding] hover:bg-white hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-primary/10 data-[active=true]:font-base data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-white data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-2 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-none ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-primary/10 data-[active=true]:font-base data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-2 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
   {
     variants: {
       variant: {
         default: "hover:bg-secondary hover:text-sidebar-accent-foreground",
         outline:
-          "bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-white hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]",
+          "bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]",
         primary:
           "bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground",
       },

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -66,6 +66,10 @@ const config = {
         sidebar: {
           DEFAULT: "hsl(var(--sidebar))",
           foreground: "hsl(var(--sidebar-foreground))",
+          border: "hsl(var(--sidebar-border))",
+          accent: "hsl(var(--sidebar-accent))",
+          "accent-foreground": "hsl(var(--sidebar-accent-foreground))",
+          ring: "hsl(var(--sidebar-ring))",
         },
         success: {
           DEFAULT: "hsl(var(--success))",


### PR DESCRIPTION
Fix sidebar theme colors to properly adapt to dark mode.

The sidebar previously used hardcoded colors and lacked specific CSS variables for dark mode, leading to a visual inconsistency where it remained light while the main content switched to dark. This PR introduces the necessary CSS variables for both light and dark modes, updates the Tailwind configuration to utilize these variables, and replaces hardcoded color classes in sidebar components with theme-aware alternatives.

---
<a href="https://cursor.com/background-agent?bcId=bc-62ed76e4-e084-41bb-8020-a16b63530223">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-62ed76e4-e084-41bb-8020-a16b63530223">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>