### PR TITLE
Fix add modal prop type error

### DIFF
--- a/src/components/integrations/AddIntegrationModalButton.tsx
+++ b/src/components/integrations/AddIntegrationModalButton.tsx
@@ -6,11 +6,13 @@ import { useState } from "react";
 interface AddIntegrationModalProps {
   brandId?: string | null;
   socialMediaPlatform: SocialMediaPlatform;
+  setIsAddModalOpen: (open: boolean) => void;
 }
 
 export function AddIntegrationModalButton({
   brandId,
   socialMediaPlatform,
+  setIsAddModalOpen,
 }: AddIntegrationModalProps) {
   const [isLoading, setIsLoading] = useState(false);
 
@@ -29,6 +31,9 @@ export function AddIntegrationModalButton({
         
         // Show a toast to inform the user
         toast.info(`Redirecting to ${socialMediaPlatform.name}...`);
+        
+        // Close the modal before redirecting
+        setIsAddModalOpen(false);
         
         // Redirect to OAuth URL in the same window (works for all devices)
         window.location.href = oauthPageUrl;


### PR DESCRIPTION
Add `setIsAddModalOpen` prop to `AddIntegrationModalButton` to fix a TypeScript error and close the modal on platform selection.

The `AddIntegrationModalButton` component was receiving a prop (`setIsAddModalOpen`) that was not defined in its interface, leading to a TypeScript error. This change resolves the error and improves the user experience by automatically closing the modal when a social media platform is selected.

---
<a href="https://cursor.com/background-agent?bcId=bc-e48c8986-df02-488b-a0fe-4f49f97a96a2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e48c8986-df02-488b-a0fe-4f49f97a96a2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>