### PR TITLE
Add and display daily posts with responsive layout

### DIFF
--- a/src/app/api/post/get-todays-posts.ts
+++ b/src/app/api/post/get-todays-posts.ts
@@ -1,0 +1,86 @@
+"use server";
+
+import { PostType, SocialMedia } from "@/generated/prisma";
+import prisma from "@/lib/prisma";
+import { getUserFromToken } from "@/lib/user";
+import { PostWithRelations } from "./types";
+
+export interface GetTodaysPostsFilter {
+  brandId?: string;
+  postType?: PostType;
+  socialMedia?: SocialMedia;
+}
+
+export async function getTodaysPosts(
+  filter?: GetTodaysPostsFilter
+): Promise<PostWithRelations[]> {
+  try {
+    const user = await getUserFromToken();
+    if (!user || !user.id || !user.teamId) {
+      throw new Error("Unauthorized");
+    }
+
+    // Get today's date range (start of day to end of day)
+    const today = new Date();
+    const startOfDay = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+    const endOfDay = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 23, 59, 59, 999);
+
+    const posts = await prisma.post.findMany({
+      where: {
+        teamId: user.teamId,
+        ...(filter?.brandId && {
+          socialMediaPosts: {
+            some: {
+              socialMediaIntegration: {
+                brandId: filter.brandId,
+              },
+            },
+          },
+        }),
+        ...(filter?.postType && {
+          postType: filter.postType,
+        }),
+        ...(filter?.socialMedia && {
+          socialMediaPosts: {
+            some: {
+              socialMedia: filter.socialMedia,
+            },
+          },
+        }),
+        // Filter for posts scheduled today
+        scheduledAt: {
+          gte: startOfDay,
+          lte: endOfDay,
+        },
+        archived: false,
+      },
+      orderBy: [
+        {
+          scheduledAt: "asc",
+        },
+        {
+          updatedAt: "asc",
+        },
+      ],
+      include: {
+        socialMediaPosts: {
+          include: {
+            socialMediaIntegration: {
+              include: {
+                brand: true,
+              },
+            },
+          },
+        },
+        images: true,
+        video: true,
+        videoCover: true,
+      },
+    });
+
+    return posts;
+  } catch (error) {
+    console.error("Error fetching today's posts:", error);
+    throw new Error("Internal Server Error");
+  }
+}

--- a/src/app/api/post/get-tomorrows-posts.ts
+++ b/src/app/api/post/get-tomorrows-posts.ts
@@ -1,0 +1,87 @@
+"use server";
+
+import { PostType, SocialMedia } from "@/generated/prisma";
+import prisma from "@/lib/prisma";
+import { getUserFromToken } from "@/lib/user";
+import { PostWithRelations } from "./types";
+
+export interface GetTomorrowsPostsFilter {
+  brandId?: string;
+  postType?: PostType;
+  socialMedia?: SocialMedia;
+}
+
+export async function getTomorrowsPosts(
+  filter?: GetTomorrowsPostsFilter
+): Promise<PostWithRelations[]> {
+  try {
+    const user = await getUserFromToken();
+    if (!user || !user.id || !user.teamId) {
+      throw new Error("Unauthorized");
+    }
+
+    // Get tomorrow's date range (start of day to end of day)
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    const startOfDay = new Date(tomorrow.getFullYear(), tomorrow.getMonth(), tomorrow.getDate());
+    const endOfDay = new Date(tomorrow.getFullYear(), tomorrow.getMonth(), tomorrow.getDate(), 23, 59, 59, 999);
+
+    const posts = await prisma.post.findMany({
+      where: {
+        teamId: user.teamId,
+        ...(filter?.brandId && {
+          socialMediaPosts: {
+            some: {
+              socialMediaIntegration: {
+                brandId: filter.brandId,
+              },
+            },
+          },
+        }),
+        ...(filter?.postType && {
+          postType: filter.postType,
+        }),
+        ...(filter?.socialMedia && {
+          socialMediaPosts: {
+            some: {
+              socialMedia: filter.socialMedia,
+            },
+          },
+        }),
+        // Filter for posts scheduled tomorrow
+        scheduledAt: {
+          gte: startOfDay,
+          lte: endOfDay,
+        },
+        archived: false,
+      },
+      orderBy: [
+        {
+          scheduledAt: "asc",
+        },
+        {
+          updatedAt: "asc",
+        },
+      ],
+      include: {
+        socialMediaPosts: {
+          include: {
+            socialMediaIntegration: {
+              include: {
+                brand: true,
+              },
+            },
+          },
+        },
+        images: true,
+        video: true,
+        videoCover: true,
+      },
+    });
+
+    return posts;
+  } catch (error) {
+    console.error("Error fetching tomorrow's posts:", error);
+    throw new Error("Internal Server Error");
+  }
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,7 +1,22 @@
-"use client";
-
 import { CreateNewPost } from "@/components/dashboard/create-new-post";
+import { TodaysTomorrowsPosts } from "@/components/dashboard/todays-tomorrows-posts";
+import { getTodaysPosts } from "@/app/api/post/get-todays-posts";
+import { getTomorrowsPosts } from "@/app/api/post/get-tomorrows-posts";
 
-export default function DashboardPage() {
-  return <CreateNewPost />;
+export default async function DashboardPage() {
+  // Fetch today's and tomorrow's posts
+  const [todaysPosts, tomorrowsPosts] = await Promise.all([
+    getTodaysPosts(),
+    getTomorrowsPosts(),
+  ]);
+
+  return (
+    <div className="space-y-8">
+      <CreateNewPost />
+      <TodaysTomorrowsPosts 
+        todaysPosts={todaysPosts} 
+        tomorrowsPosts={tomorrowsPosts} 
+      />
+    </div>
+  );
 }

--- a/src/components/dashboard/dashboard-post-card.tsx
+++ b/src/components/dashboard/dashboard-post-card.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { PostWithRelations } from "@/app/api/post/types";
+import { PostType } from "@/generated/prisma";
+import { socialMediaPlatforms } from "@/lib/social-media-platforms";
+import { format } from "date-fns";
+import { ImageIcon, TextIcon, VideoIcon } from "lucide-react";
+import Link from "next/link";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+function getPlatforms(post: PostWithRelations) {
+  const platforms = Array.from(
+    new Set(post.socialMediaPosts.map((smp) => smp.socialMedia))
+  );
+  return platforms;
+}
+
+function getPostTypeIcon(postType: PostType) {
+  switch (postType) {
+    case PostType.TEXT:
+      return <TextIcon className="h-4 w-4" />;
+    case PostType.IMAGE:
+      return <ImageIcon className="h-4 w-4" />;
+    case PostType.VIDEO:
+      return <VideoIcon className="h-4 w-4" />;
+    default:
+      return null;
+  }
+}
+
+function getPostStatus(post: PostWithRelations) {
+  const hasFailed = post.socialMediaPosts.some(
+    (socialMediaPost) => socialMediaPost.failedAt
+  );
+  const hasPosted = post.socialMediaPosts.some(
+    (socialMediaPost) => socialMediaPost.postedAt
+  );
+  const isPending = post.scheduledAt && post.scheduledAt < new Date();
+
+  if (hasFailed) return "Failed";
+  if (hasPosted) return "Posted";
+  if (isPending) return "Pending";
+  if (post.scheduledAt) return "Scheduled";
+  return "Draft";
+}
+
+function getStatusColor(status: string) {
+  switch (status) {
+    case "Failed":
+      return "text-destructive";
+    case "Posted":
+      return "text-green-600";
+    case "Pending":
+      return "text-orange-600";
+    case "Scheduled":
+      return "text-blue-600";
+    default:
+      return "text-muted-foreground";
+  }
+}
+
+interface DashboardPostCardProps {
+  post: PostWithRelations;
+}
+
+export function DashboardPostCard({ post }: DashboardPostCardProps) {
+  const platforms = getPlatforms(post);
+  const brand = post.socialMediaPosts[0]?.socialMediaIntegration?.brand;
+  const status = getPostStatus(post);
+  const statusColor = getStatusColor(status);
+
+  return (
+    <Link href={`/dashboard/posts/${post.id}`} className="block">
+      <Card className="hover:bg-secondary transition-colors cursor-pointer h-full">
+        <CardHeader className="pb-3">
+          <CardTitle>
+            <div className="flex items-start gap-2">
+              <div className="shrink-0 mt-0.5">
+                {getPostTypeIcon(post.postType)}
+              </div>
+              <p className="text-sm font-normal text-muted-foreground line-clamp-2">
+                {post.description}
+              </p>
+            </div>
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="pt-0">
+          <div className="flex items-center justify-between gap-4">
+            <div className="flex items-center gap-2">
+              <div className="text-sm font-medium">
+                {brand ? brand.name : "No Brand"}
+              </div>
+              <div className="flex items-center gap-1">
+                {platforms.map((platform) => {
+                  const platformObj = socialMediaPlatforms.find(
+                    (p) => p.id === platform
+                  );
+                  if (!platformObj) return null;
+                  return (
+                    <platformObj.Icon key={platform} className="w-4 h-4" />
+                  );
+                })}
+              </div>
+            </div>
+
+            <div className="flex flex-col items-end gap-1">
+              {post.scheduledAt && (
+                <span className="text-xs text-muted-foreground">
+                  {format(new Date(post.scheduledAt), "HH:mm")}
+                </span>
+              )}
+              <span className={`text-xs font-medium ${statusColor}`}>
+                {status}
+              </span>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}

--- a/src/components/dashboard/todays-tomorrows-posts.tsx
+++ b/src/components/dashboard/todays-tomorrows-posts.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { PostWithRelations } from "@/app/api/post/types";
+import { format } from "date-fns";
+import { DashboardPostCard } from "./dashboard-post-card";
+
+interface TodaysTomorrowsPostsProps {
+  todaysPosts: PostWithRelations[];
+  tomorrowsPosts: PostWithRelations[];
+}
+
+export function TodaysTomorrowsPosts({ 
+  todaysPosts, 
+  tomorrowsPosts 
+}: TodaysTomorrowsPostsProps) {
+  const today = new Date();
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+
+  return (
+    <div className="flex flex-col lg:flex-row gap-6 lg:gap-8">
+      {/* Today's Posts */}
+      <div className="flex-1 space-y-4">
+        <h2 className="text-xl font-semibold">
+          Today, {format(today, "MMM d, yyyy")}
+        </h2>
+        {todaysPosts.length > 0 ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2 gap-4">
+            {todaysPosts.map((post) => (
+              <DashboardPostCard key={post.id} post={post} />
+            ))}
+          </div>
+        ) : (
+          <p className="text-muted-foreground text-sm">
+            No posts scheduled for today.
+          </p>
+        )}
+      </div>
+
+      {/* Tomorrow's Posts */}
+      <div className="flex-1 space-y-4">
+        <h2 className="text-xl font-semibold">
+          Tomorrow, {format(tomorrow, "MMM d, yyyy")}
+        </h2>
+        {tomorrowsPosts.length > 0 ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2 gap-4">
+            {tomorrowsPosts.map((post) => (
+              <DashboardPostCard key={post.id} post={post} />
+            ))}
+          </div>
+        ) : (
+          <p className="text-muted-foreground text-sm">
+            No posts scheduled for tomorrow.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Add API functions and dashboard components to display today's and tomorrow's scheduled posts with responsive styling.

---
<a href="https://cursor.com/background-agent?bcId=bc-e3aad44f-8248-4f1a-a5a0-5d2e84e86177">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e3aad44f-8248-4f1a-a5a0-5d2e84e86177">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

