### PR TITLE
Add breadcrumbs to dashboard pages

### DIFF
--- a/src/app/dashboard/brands/page.tsx
+++ b/src/app/dashboard/brands/page.tsx
@@ -1,10 +1,16 @@
 import { getBrands } from "@/app/api/brand/get-brands";
 import { BrandList } from "@/components/brands/BrandList";
+import { Breadcrumb } from "@/components/common/breadcrumb";
 
 export const dynamic = "force-dynamic";
 
 export default async function BrandsPage() {
   const brands = await getBrands();
 
-  return <BrandList brands={brands} />;
+  return (
+    <div>
+      <Breadcrumb label="Brands" href="/dashboard/brands" />
+      <BrandList brands={brands} />
+    </div>
+  );
 }

--- a/src/app/dashboard/create-new-post/image/page.tsx
+++ b/src/app/dashboard/create-new-post/image/page.tsx
@@ -1,6 +1,7 @@
 import { ImagePostForm } from "@/components/post-forms/image-post-form";
 import { Header } from "@/components/common/Header";
 import { getSocialMediaIntegrations } from "@/app/api/social-media-integration/get-social-media-integrations";
+import { Breadcrumb } from "@/components/common/breadcrumb";
 
 interface ImagePostPageProps {
   searchParams: Promise<{ date?: string }>;
@@ -12,6 +13,7 @@ export default async function ImagePostPage({ searchParams }: ImagePostPageProps
 
   return (
     <div className="space-y-4">
+      <Breadcrumb label="Image" href="/dashboard/create-new-post/image" />
       <Header>Create new image post</Header>
       <ImagePostForm integrations={integrations} initialDate={date} />
     </div>

--- a/src/app/dashboard/create-new-post/page.tsx
+++ b/src/app/dashboard/create-new-post/page.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import { CreateNewPost } from "@/components/dashboard/create-new-post";
+import { Breadcrumb } from "@/components/common/breadcrumb";
 
 export default function CreateNewPostPage() {
-  return <CreateNewPost />;
+  return (
+    <div>
+      <Breadcrumb label="Create New Post" href="/dashboard/create-new-post" />
+      <CreateNewPost />
+    </div>
+  );
 }

--- a/src/app/dashboard/create-new-post/text/page.tsx
+++ b/src/app/dashboard/create-new-post/text/page.tsx
@@ -1,6 +1,7 @@
 import { TextPostForm } from "@/components/post-forms/text-post-form";
 import { Header } from "@/components/common/Header";
 import { getSocialMediaIntegrations } from "@/app/api/social-media-integration/get-social-media-integrations";
+import { Breadcrumb } from "@/components/common/breadcrumb";
 
 interface TextPostPageProps {
   searchParams: Promise<{ date?: string }>;
@@ -12,6 +13,7 @@ export default async function TextPostPage({ searchParams }: TextPostPageProps) 
 
   return (
     <div className="space-y-4">
+      <Breadcrumb label="Text" href="/dashboard/create-new-post/text" />
       <Header>Create new text post</Header>
       <TextPostForm integrations={integrations} initialDate={date} />
     </div>

--- a/src/app/dashboard/create-new-post/video/page.tsx
+++ b/src/app/dashboard/create-new-post/video/page.tsx
@@ -1,6 +1,7 @@
 import { VideoPostForm } from "@/components/post-forms/video-post-form";
 import { Header } from "@/components/common/Header";
 import { getSocialMediaIntegrations } from "@/app/api/social-media-integration/get-social-media-integrations";
+import { Breadcrumb } from "@/components/common/breadcrumb";
 
 interface VideoPostPageProps {
   searchParams: Promise<{ date?: string }>;
@@ -12,6 +13,7 @@ export default async function VideoPostPage({ searchParams }: VideoPostPageProps
 
   return (
     <div className="space-y-4">
+      <Breadcrumb label="Video" href="/dashboard/create-new-post/video" />
       <Header>Create new video post</Header>
       <VideoPostForm integrations={integrations} initialDate={date} />
     </div>

--- a/src/app/dashboard/debug/page.tsx
+++ b/src/app/dashboard/debug/page.tsx
@@ -1,5 +1,6 @@
 import { PostPostsDebugButton } from "@/components/debug/post-posts-debug-button";
 import { ArchivePostsDebugButton } from "@/components/debug/archive-posts-debug-button";
+import { Breadcrumb } from "@/components/common/breadcrumb";
 
 export default function DebugPage() {
   if (!process.env.CRON_SECRET) {
@@ -8,6 +9,7 @@ export default function DebugPage() {
 
   return (
     <div className="flex flex-col gap-4">
+      <Breadcrumb label="Debug" href="/dashboard/debug" />
       <PostPostsDebugButton secret={process.env.CRON_SECRET} />
       <ArchivePostsDebugButton secret={process.env.CRON_SECRET} />
     </div>

--- a/src/app/dashboard/integrations/page.tsx
+++ b/src/app/dashboard/integrations/page.tsx
@@ -1,6 +1,7 @@
 import { getBrands } from "@/app/api/brand/get-brands";
 import { getSocialMediaIntegrations } from "@/app/api/social-media-integration/get-social-media-integrations";
 import { AllIntegrationsList } from "@/components/integrations/AllIntegrationsList";
+import { Breadcrumb } from "@/components/common/breadcrumb";
 
 export default async function IntegrationsPage() {
   const brands = await getBrands();
@@ -8,6 +9,7 @@ export default async function IntegrationsPage() {
 
   return (
     <div className="space-y-8">
+      <Breadcrumb label="Integrations" href="/dashboard/integrations" />
       <AllIntegrationsList brands={brands} integrations={integrations} />
     </div>
   );

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -2,6 +2,7 @@ import { AuthProviderWrapper } from "@/components/auth/auth-provider-wrapper";
 import { DashboardSidebar } from "@/components/DashboardSidebar";
 import { MobileTopNav } from "@/components/MobileTopNav";
 import { SidebarProvider } from "@/components/ui/sidebar";
+import { Breadcrumbs } from "@/components/common/breadcrumbs";
 import { Metadata } from "next";
 
 export const dynamic = "force-dynamic";
@@ -25,6 +26,7 @@ export default function DashboardLayout({
             <DashboardSidebar />
             <main className="flex-1 flex justify-center overflow-x-auto">
               <div className="container flex flex-col space-y-6 max-sm:py-4">
+                <Breadcrumbs />
                 {children}
               </div>
             </main>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -4,6 +4,7 @@ import { getTodaysPosts } from "@/app/api/post/get-todays-posts";
 import { getTomorrowsPosts } from "@/app/api/post/get-tomorrows-posts";
 import { Header } from "@/components/common/Header";
 import { PlusButton } from "@/components/dashboard/plus-button";
+import { Breadcrumb } from "@/components/common/breadcrumb";
 import { format } from "date-fns";
 
 export default async function DashboardPage() {
@@ -19,6 +20,7 @@ export default async function DashboardPage() {
 
   return (
     <div className="space-y-6">
+      <Breadcrumb label="Dashboard" href="/dashboard" />
       <CreateNewPost />
       
       <div className="flex flex-col lg:flex-row gap-6 lg:gap-8">

--- a/src/app/dashboard/posts/[slug]/page.tsx
+++ b/src/app/dashboard/posts/[slug]/page.tsx
@@ -10,6 +10,7 @@ import { VideoPostForm } from "@/components/post-forms/video-post-form";
 import { PostType } from "@/generated/prisma";
 import { postIsEditable } from "@/lib/post";
 import { notFound } from "next/navigation";
+import { Breadcrumb } from "@/components/common/breadcrumb";
 
 interface PostPageProps {
   params: Promise<{
@@ -26,14 +27,17 @@ export default async function PostPage({ params }: PostPageProps) {
       getSocialMediaIntegrations(),
     ]);
 
+    const postTypeLabel = post.postType === PostType.TEXT
+      ? "Text Post"
+      : post.postType === PostType.IMAGE
+      ? "Image Post"
+      : "Video Post";
+
     return (
       <div className="space-y-4">
+        <Breadcrumb label={postTypeLabel} href={`/dashboard/posts/${slug}`} />
         <Header>
-          {post.postType === PostType.TEXT
-            ? "Text Post"
-            : post.postType === PostType.IMAGE
-            ? "Image Post"
-            : "Video Post"}
+          {postTypeLabel}
         </Header>
 
         {postIsEditable(post) ? (

--- a/src/app/dashboard/posts/page.tsx
+++ b/src/app/dashboard/posts/page.tsx
@@ -3,6 +3,7 @@
 import { getBrands } from "@/app/api/brand/get-brands";
 import { getPosts, GetPostsFilter } from "@/app/api/post/get-posts";
 import { WeeklyCalendar } from "@/components/posts/WeeklyCalendar";
+import { Breadcrumb } from "@/components/common/breadcrumb";
 
 type PostsProps = {
   searchParams: Promise<{
@@ -26,5 +27,10 @@ export default async function PostsPage({ searchParams }: PostsProps) {
 
   const brands = await getBrands();
 
-  return <WeeklyCalendar posts={posts} brands={brands} />;
+  return (
+    <div>
+      <Breadcrumb label="Posts" href="/dashboard/posts" />
+      <WeeklyCalendar posts={posts} brands={brands} />
+    </div>
+  );
 }

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -1,10 +1,12 @@
 import { LogoutButton } from "@/components/profile/LogoutButton";
 import { PasswordChangeForm } from "@/components/profile/PasswordChangeForm";
 import { ProfileInfoForm } from "@/components/profile/ProfileInfoForm";
+import { Breadcrumb } from "@/components/common/breadcrumb";
 
 export default function ProfilePage() {
   return (
     <div className="space-y-8">
+      <Breadcrumb label="Profile" href="/dashboard/profile" />
       <ProfileInfoForm />
       <PasswordChangeForm />
       <div className="flex justify-end">

--- a/src/app/dashboard/team/page.tsx
+++ b/src/app/dashboard/team/page.tsx
@@ -1,5 +1,6 @@
 import { getTeamWithMembers } from "@/app/api/team/get-team-with-members";
 import { TeamList } from "@/components/team/TeamList";
+import { Breadcrumb } from "@/components/common/breadcrumb";
 
 export const dynamic = "force-dynamic";
 
@@ -10,5 +11,10 @@ export default async function TeamPage() {
     throw new Error("Team not found");
   }
 
-  return <TeamList team={team} />;
+  return (
+    <div>
+      <Breadcrumb label="Team" href="/dashboard/team" />
+      <TeamList team={team} />
+    </div>
+  );
 }


### PR DESCRIPTION
Add breadcrumbs to all pages under `/dashboard` to improve navigation.

---
<a href="https://cursor.com/background-agent?bcId=bc-73e2c8de-8066-4e4a-934d-6060952f2c38">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-73e2c8de-8066-4e4a-934d-6060952f2c38">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

