### PR TITLE
Fix breadcrumb reset on route navigation

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -3,6 +3,7 @@ import { DashboardSidebar } from "@/components/DashboardSidebar";
 import { MobileTopNav } from "@/components/MobileTopNav";
 import { SidebarProvider } from "@/components/ui/sidebar";
 import { Breadcrumbs } from "@/components/common/breadcrumbs";
+import { BreadcrumbsProvider } from "@/components/common/breadcrumbs-context";
 import { Metadata } from "next";
 
 export const dynamic = "force-dynamic";
@@ -26,8 +27,10 @@ export default function DashboardLayout({
             <DashboardSidebar />
             <main className="flex-1 flex justify-center overflow-x-auto">
               <div className="container flex flex-col space-y-6 max-sm:py-4">
-                <Breadcrumbs />
-                <div id="breadcrumb-scope">{children}</div>
+                <BreadcrumbsProvider>
+                  <Breadcrumbs />
+                  {children}
+                </BreadcrumbsProvider>
               </div>
             </main>
           </div>

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -27,7 +27,7 @@ export default function DashboardLayout({
             <main className="flex-1 flex justify-center overflow-x-auto">
               <div className="container flex flex-col space-y-6 max-sm:py-4">
                 <Breadcrumbs />
-                {children}
+                <div id="breadcrumb-scope">{children}</div>
               </div>
             </main>
           </div>

--- a/src/components/common/breadcrumb.tsx
+++ b/src/components/common/breadcrumb.tsx
@@ -1,10 +1,20 @@
+"use client";
+
+import { useEffect } from "react";
+import { useBreadcrumbs } from "./breadcrumbs-context";
+
 interface BreadcrumbProps {
   label: string;
   href?: string;
 }
 
 export function Breadcrumb({ label, href }: BreadcrumbProps) {
-  return (
-    <span className="breadcrumb hidden" data-label={label} data-href={href} />
-  );
+  const { registerBreadcrumb, deregisterBreadcrumb } = useBreadcrumbs();
+
+  useEffect(() => {
+    registerBreadcrumb(label, href);
+    return () => deregisterBreadcrumb(label, href);
+  }, [label, href, registerBreadcrumb, deregisterBreadcrumb]);
+
+  return null;
 }

--- a/src/components/common/breadcrumbs-context.tsx
+++ b/src/components/common/breadcrumbs-context.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+export type BreadcrumbItem = {
+  label: string;
+  href?: string;
+  key: string;
+};
+
+export type BreadcrumbsContextValue = {
+  items: BreadcrumbItem[];
+  registerBreadcrumb: (label: string, href?: string) => void;
+  deregisterBreadcrumb: (label: string, href?: string) => void;
+  resetBreadcrumbs: () => void;
+};
+
+const BreadcrumbsContext = createContext<BreadcrumbsContextValue | undefined>(
+  undefined
+);
+
+export function BreadcrumbsProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [items, setItems] = useState<BreadcrumbItem[]>([]);
+  const itemKeysRef = useRef<Set<string>>(new Set());
+  const pathname = usePathname();
+
+  const registerBreadcrumb = useCallback((label: string, href?: string) => {
+    const key = `${label}|${href ?? ""}`;
+    if (itemKeysRef.current.has(key)) return;
+    itemKeysRef.current.add(key);
+    setItems((prev) => [...prev, { label, href, key }]);
+  }, []);
+
+  const deregisterBreadcrumb = useCallback((label: string, href?: string) => {
+    const key = `${label}|${href ?? ""}`;
+    if (!itemKeysRef.current.has(key)) return;
+    itemKeysRef.current.delete(key);
+    setItems((prev) => prev.filter((i) => i.key !== key));
+  }, []);
+
+  const resetBreadcrumbs = useCallback(() => {
+    itemKeysRef.current = new Set();
+    setItems([]);
+  }, []);
+
+  useEffect(() => {
+    // Reset breadcrumbs on every pathname change
+    resetBreadcrumbs();
+  }, [pathname, resetBreadcrumbs]);
+
+  const value = useMemo(
+    () => ({ items, registerBreadcrumb, deregisterBreadcrumb, resetBreadcrumbs }),
+    [items, registerBreadcrumb, deregisterBreadcrumb, resetBreadcrumbs]
+  );
+
+  return (
+    <BreadcrumbsContext.Provider value={value}>
+      {children}
+    </BreadcrumbsContext.Provider>
+  );
+}
+
+export function useBreadcrumbs() {
+  const ctx = useContext(BreadcrumbsContext);
+  if (!ctx) {
+    throw new Error("useBreadcrumbs must be used within a BreadcrumbsProvider");
+  }
+  return ctx;
+}

--- a/src/components/common/breadcrumbs.tsx
+++ b/src/components/common/breadcrumbs.tsx
@@ -13,7 +13,26 @@ export function Breadcrumbs() {
   const [breadcrumbElements, setBreadcrumbElements] = useState<Element[]>([]);
 
   useEffect(() => {
-    setBreadcrumbElements(Array.from(document.querySelectorAll(".breadcrumb")));
+    const scope = document.getElementById("breadcrumb-scope");
+    const elements = scope
+      ? Array.from(scope.querySelectorAll(".breadcrumb"))
+      : [];
+
+    const seenKeys = new Set<string>();
+    const uniqueElements: Element[] = [];
+
+    for (const element of elements) {
+      const label = element.getAttribute("data-label") ?? "";
+      const href = element.getAttribute("data-href") ?? "";
+      const key = `${label}|${href}`;
+
+      if (!seenKeys.has(key)) {
+        seenKeys.add(key);
+        uniqueElements.push(element);
+      }
+    }
+
+    setBreadcrumbElements(uniqueElements);
   }, [pathname]);
 
   return (

--- a/src/components/common/breadcrumbs.tsx
+++ b/src/components/common/breadcrumbs.tsx
@@ -2,38 +2,11 @@
 
 import { ChevronRight, Home } from "lucide-react";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
-
 import { Button } from "@/components/ui/button";
-import { useEffect, useState } from "react";
+import { useBreadcrumbs } from "./breadcrumbs-context";
 
 export function Breadcrumbs() {
-  const pathname = usePathname();
-
-  const [breadcrumbElements, setBreadcrumbElements] = useState<Element[]>([]);
-
-  useEffect(() => {
-    const scope = document.getElementById("breadcrumb-scope");
-    const elements = scope
-      ? Array.from(scope.querySelectorAll(".breadcrumb"))
-      : [];
-
-    const seenKeys = new Set<string>();
-    const uniqueElements: Element[] = [];
-
-    for (const element of elements) {
-      const label = element.getAttribute("data-label") ?? "";
-      const href = element.getAttribute("data-href") ?? "";
-      const key = `${label}|${href}`;
-
-      if (!seenKeys.has(key)) {
-        seenKeys.add(key);
-        uniqueElements.push(element);
-      }
-    }
-
-    setBreadcrumbElements(uniqueElements);
-  }, [pathname]);
+  const { items } = useBreadcrumbs();
 
   return (
     <nav className="flex items-center space-x-2 text-sm text-muted-foreground">
@@ -49,25 +22,20 @@ export function Breadcrumbs() {
         </Link>
       </Button>
 
-      {breadcrumbElements.map((breadcrumb) => {
-        const label = breadcrumb.getAttribute("data-label");
-        const href = breadcrumb.getAttribute("data-href");
-
-        return (
-          <Button
-            key={label + (href ?? "")}
-            variant="ghost"
-            size="sm"
-            className="h-auto p-0 hover:bg-transparent"
-            asChild
-          >
-            <Link href={href ?? ""}>
-              <ChevronRight className="h-4 w-4" />
-              {label}
-            </Link>
-          </Button>
-        );
-      })}
+      {items.map(({ key, label, href }) => (
+        <Button
+          key={key}
+          variant="ghost"
+          size="sm"
+          className="h-auto p-0 hover:bg-transparent"
+          asChild
+        >
+          <Link href={href ?? ""}>
+            <ChevronRight className="h-4 w-4" />
+            {label}
+          </Link>
+        </Button>
+      ))}
     </nav>
   );
 }


### PR DESCRIPTION
Scope breadcrumb collection to the current route and deduplicate entries to prevent accumulation across navigations.

---
<a href="https://cursor.com/background-agent?bcId=bc-4f1504d4-b962-42d2-b0c5-5b60ab1fbc51">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4f1504d4-b962-42d2-b0c5-5b60ab1fbc51">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

